### PR TITLE
feat: Handle area and line geometry for all S-57 objects

### DIFF
--- a/include/oesenc/s57.h
+++ b/include/oesenc/s57.h
@@ -164,7 +164,8 @@ public:
 
     void buildGeometry(const std::unordered_map<unsigned int, S57::VectorEdge> &vectorEdges,
                        const std::unordered_map<unsigned int, S57::ConnectedNode> &connectedNodes);
-    void setLineGeometry(LineElement *elements, int length);
+    void setLineGeometry(const LineElement *elements, int length);
+    void setPolygonGeometry(const LineElement *elements, int length);
     void setPointGeometry(const oesenc::Position &position);
     void setMultiPointGeometry(std::vector<PointGeometry> points);
 
@@ -185,9 +186,10 @@ private:
     void buildArea(const std::unordered_map<unsigned int, S57::VectorEdge> &vectorEdges,
                    const std::unordered_map<unsigned int, S57::ConnectedNode> &connectedNodes);
     std::vector<LineElement> m_lineElements;
+    std::vector<LineElement> m_polygonLineElements;
     std::vector<MultiGeometry> m_lines;
-    Type m_type = Type::Unknown;
     std::vector<MultiGeometry> m_polygons;
+    Type m_type = Type::Unknown;
     std::vector<PointGeometry> m_multiPointGeometry;
     std::optional<oesenc::Position> m_pointGeometry;
     std::unordered_map<Attribute, std::variant<uint32_t, float, std::string>> m_attributes;

--- a/src/chartfile.cpp
+++ b/src/chartfile.cpp
@@ -354,7 +354,7 @@ bool ChartFile::ingest200(IReader *fpx,
             next_byte = skipTessellationData(pPayload);
 
             if (s57 != nullptr) {
-                s57->setLineGeometry(reinterpret_cast<S57::LineElement *>(next_byte),
+                s57->setPolygonGeometry(reinterpret_cast<S57::LineElement *>(next_byte),
                                      pPayload->edgeVector_count);
             }
 

--- a/src/s57.cpp
+++ b/src/s57.cpp
@@ -1,4 +1,5 @@
-﻿#include <iostream>
+﻿#include <cassert>
+#include <iostream>
 
 #include "oesenc/s57.h"
 
@@ -208,9 +209,14 @@ S57::Type S57::type() const
     return m_type;
 }
 
-void S57::setLineGeometry(LineElement *elements, int length)
+void S57::setLineGeometry(const LineElement *elements, int length)
 {
     m_lineElements.assign(elements, elements + length);
+}
+
+void S57::setPolygonGeometry(const LineElement *elements, int length)
+{
+    m_polygonLineElements.assign(elements, elements + length);
 }
 
 void S57::setMultiPointGeometry(std::vector<PointGeometry> points)
@@ -221,20 +227,9 @@ void S57::setMultiPointGeometry(std::vector<PointGeometry> points)
 void S57::buildGeometry(const std::unordered_map<unsigned int, S57::VectorEdge> &vectorEdges,
                         const std::unordered_map<unsigned int, S57::ConnectedNode> &connectedNodes)
 {
-    switch (m_type) {
-    case S57::Type::LandArea:
-    case S57::Type::DepthArea:
-    case S57::Type::BuiltUpArea:
-    case S57::Type::Coverage:
-        m_polygons = buildGeometries<MultiGeometry>(m_lineElements, vectorEdges, connectedNodes);
-        break;
-    case S57::Type::CoastLine:
-    case S57::Type::Road:
-        m_lines = buildGeometries<MultiGeometry>(m_lineElements, vectorEdges, connectedNodes);
-        break;
-    default:
-        break;
-    }
+
+    m_lines = buildGeometries<MultiGeometry>(m_lineElements, vectorEdges, connectedNodes);
+    m_polygons = buildGeometries<MultiGeometry>(m_polygonLineElements, vectorEdges, connectedNodes);
 }
 
 template <typename T>


### PR DESCRIPTION
FEATURE_GEOMETRY_RECORD_AREA and FEATURE_GEOMETRY_RECORD_LINE was handled the same way. But those actually tell what kind of geometry the object has. Because this is now solved the buildGeometry() function can now be called for all objects both for line and area geometry.