### PR TITLE
feat: Add callback for vector edge decimation function

### DIFF
--- a/include/oesenc/chartfile.h
+++ b/include/oesenc/chartfile.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -352,8 +353,14 @@ class IReader;
 class OESENC_EXPORT ChartFile
 {
 public:
-    ChartFile(const std::string &filename);
-    ChartFile(const std::vector<std::byte> &data);
+    struct Config
+    {
+        using Line = std::vector<Position>;
+        std::function<Line(Line)> vectorEdgeDecimator = nullptr;
+    };
+
+    ChartFile(const std::string &filename, const Config &config = Config { nullptr });
+    ChartFile(const std::vector<std::byte> &data, const Config &config = Config { nullptr });
     ~ChartFile();
     bool readHeaders();
     bool read();
@@ -395,6 +402,7 @@ private:
 
     unsigned char *pBuffer = nullptr;
     size_t bufferSize = 0;
+    Config m_config;
     Rect m_extent;
     std::shared_ptr<IReader> m_reader;
     std::vector<S57> m_s57;

--- a/src/chartfile.cpp
+++ b/src/chartfile.cpp
@@ -44,14 +44,16 @@
 
 using namespace oesenc;
 
-ChartFile::ChartFile(const std::string &filename)
+ChartFile::ChartFile(const std::string &filename, const Config &config)
     : m_filename(filename)
+    , m_config(config)
 {
     m_reader = std::make_shared<FileReader>(m_filename);
 }
 
-ChartFile::ChartFile(const std::vector<std::byte> &data)
+ChartFile::ChartFile(const std::vector<std::byte> &data, const Config &config)
     : m_data(data)
+    , m_config(config)
 {
     m_reader = std::make_shared<VectorReader>(data);
 }
@@ -437,6 +439,11 @@ bool ChartFile::ingest200(IReader *fpx,
                                                                     pPoints[i * 2 + 1],
                                                                     ref));
                 }
+
+                if (m_config.vectorEdgeDecimator) {
+                    positions = m_config.vectorEdgeDecimator(positions);
+                }
+
                 free(pPoints);
                 vectorEdge.setPositions(positions);
                 vectorEdges[featureIndex] = vectorEdge;


### PR DESCRIPTION
This lets the user of the library use a custom decimation function for vector edges.