### PR TITLE
Add safe guard for opening a dead pipe

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,10 +3,16 @@ find_package(GTest REQUIRED)
 enable_testing()
 
 function(addTest)
-    set(BASENAME ${ARGV0}_test)
+    set(oneValueArgs NAME TIMEOUT)
+    cmake_parse_arguments(ADD_TEST "" "${oneValueArgs}" "" ${ARGN})
+    set(BASENAME ${ADD_TEST_NAME}_test)
     add_executable(${BASENAME} ${BASENAME}.cpp)
     target_link_libraries(${BASENAME} PRIVATE GTest::gtest GTest::gtest_main oesenc)
     add_test(NAME ${BASENAME} COMMAND ${BASENAME})
+
+    if(ADD_TEST_TIMEOUT)
+        set_tests_properties(${BASENAME} PROPERTIES TIMEOUT ${ADD_TEST_TIMEOUT})
+    endif()
 
     if(WIN32 AND BUILD_SHARED_LIBS)
         add_custom_command(TARGET ${BASENAME} POST_BUILD
@@ -16,9 +22,9 @@ function(addTest)
     endif()
 endfunction()
 
-addTest(chartfile)
-addTest(servercontrol)
+addTest(NAME chartfile)
+addTest(NAME servercontrol TIMEOUT 30)
 
 if(OESENC_KEYLISTREADER_ENABLED)
-    addTest(keylistreader)
+    addTest(NAME keylistreader)
 endif()

--- a/tests/servercontrol_test.cpp
+++ b/tests/servercontrol_test.cpp
@@ -97,6 +97,24 @@ TEST(ServerControl, ReusesServer)
     ASSERT_EQ(pipeName, serverControl.pipeName());
 }
 
+#ifdef OESENC_LINUX
+TEST(ServerControl, DontBlockOnDeadPipe)
+{
+    string pipeName;
+    {
+        ServerControl serverControl(ServerControl::Flags::DontStartServer
+                                    | ServerControl::Flags::LeaveServerRunning);
+        pipeName = serverControl.pipeName();
+        mkfifo(pipeName.c_str(), 0666);
+    }
+
+    ServerControl serverControl(ServerControl::Flags::DontStartServer);
+
+    ASSERT_FALSE(serverControl.isReady());
+    remove(pipeName.c_str());
+}
+#endif
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This commit adds a check to avoid situations on Linux where a /tmp/OCPN_PIPEX fifo is present, but not a oexserverd process reading it. Trying to fopen it would block which is undesirable.