### PR TITLE
Use debian build of oexserverd in tests

### DIFF
--- a/get_oexserverd.sh
+++ b/get_oexserverd.sh
@@ -6,7 +6,7 @@ export LC_ALL=en_US.utf8
 
 case "$OSTYPE" in
   linux*)
-	PLUGIN_REGEXP="(?<=<tarball-url>).*o-charts.*-ubuntu-22.04.*x86.*?(?=</tarball-url>)"
+	PLUGIN_REGEXP="(?<=<tarball-url>).*o-charts.*-debian-x86_64.*?(?=</tarball-url>)"
   ;;
   msys*|cygwin)
 	PLUGIN_REGEXP="(?<=<tarball-url>).*o-charts.*msvc.*win32.*?(?=</tarball-url>)"


### PR DESCRIPTION
Ubuntu builds disappeared here:
https://github.com/OpenCPN/plugins/commit/a5a94dbad5886220d8130b06295dd246c1bc02ec